### PR TITLE
docs: Fix rendering of infrastructure stack list

### DIFF
--- a/docs/stack.md
+++ b/docs/stack.md
@@ -1,5 +1,6 @@
 # Backstage Infrastructure Stack
-The infrastructure stack to host backstage consists of  
+The infrastructure stack to host backstage consists of:
+
 - ECS Fargate cluster
 - ECS Service definition
 - ECS Task definitions for each stage (Test, Prod)


### PR DESCRIPTION
python-markdown needs a newline to render a list.

https://rianbogle.com/backstage-on-aws/stack/